### PR TITLE
Update import for show_install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Here are some ways that you can learn a lot about the library, whilst also contr
 * Nobody is perfect, especially not us. But first, please double-check the bug doesn't come from something on your side. The [forum](http://forums.fast.ai/) is a tremendous source for help, and we'd advise to use it as a first step. Be sure to include as much code as you can so that other people can easily help you.
 * Then, ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/fastai/fastai/issues).
 * If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/fastai/fastai/issues/new). Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
-* Be sure to add the complete error messages as well as the result of the line `import fastai.utils.collect_env; fastai.utils.collect_env.show_install(1)`.
+* Be sure to add the complete error messages as well as the result of the line `from fastai import test_utils; fastai.test_utils.show_install(1)`.
 
 #### Did you write a patch that fixes a bug?
 


### PR DESCRIPTION
show_install was moved at some point to test_utils from utils.collect_env.
This updates the contributor guide so people will know how to
print version information.